### PR TITLE
fix: update S3 bucket deployment logic to establish folder structure

### DIFF
--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -199,11 +199,12 @@ export class jobsearch1 extends cdk.Stack {
       ],
     });
 
-    const prefixes = ['public/', 'private/', ];
+    // Create placeholder files to establish folder structure
+    const prefixes = ['public/', 'private/'];
 
     prefixes.forEach(prefix => {
       new s3deploy.BucketDeployment(this, `Deploy${prefix.replace('/', '')}`, {
-        sources: [s3deploy.Source.data(`${prefix.replace('/', '')}.placeholder`, "")],
+        sources: [s3deploy.Source.data(" ", `${prefix.replace('/', '')}.placeholder`)],
         destinationBucket: carrierResourcesBucket,
         destinationKeyPrefix: prefix,
       })


### PR DESCRIPTION
- Added placeholder files to the S3 bucket deployment process to ensure the creation of the public and private folder structure.
- Adjusted the source data for bucket deployment to correctly reference the placeholder files.