### PR TITLE
fix: update S3 bucket public access settings for improved security

### DIFF
--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -182,7 +182,7 @@ export class jobsearch1 extends cdk.Stack {
     const carrierResourcesBucket = new s3.Bucket(this, "carrierResourcesBucket", {
       enforceSSL: true,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ACLS,
       cors: [
         {
           allowedHeaders: ["*"],


### PR DESCRIPTION
- Changed the S3 bucket configuration to block ACLs instead of all public access, refining access control while maintaining CORS settings.